### PR TITLE
Update handle-file.helper.js

### DIFF
--- a/src/helpers/handle-file.helper.js
+++ b/src/helpers/handle-file.helper.js
@@ -37,7 +37,7 @@ const getPath = function(path) {
             let pathMap = checkOS.test(pathLib.resolve("./")) ? path.toLowerCase().split("/") : path.toLowerCase().split("\\");
             let intersection = pathMap.filter(x => dirnameMap.includes(x));
             if (intersection.length > 2) {
-                return pathLib.resolve(`./${path}`);
+                return pathLib.resolve(`${path}`);
             } else {
                 return path;
             }


### PR DESCRIPTION
Remove redundant path in windows 11 when run cmd "dev chrome -lg"

Log errors:
C:\Users\ThinhNguyen\Desktop\kr-cli-main>node ./src/index.js dev chrome -lg
1.1.0
>> [ERROR] Error message: C:\Users\ThinhNguyen\Desktop\kr-cli-main\C:\Users\ThinhNguyen\Desktop\kr-cli-main\tests\kr-test
>> [ERROR] Error message: The path doesn't exists. C:\Users\ThinhNguyen\Desktop\kr-cli-main\C:\Users\ThinhNguyen\Desktop\kr-cli-main\tests\kr-test
>> [ERROR] Error message: The path is not valid. Please try again!